### PR TITLE
Update date gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,3 +36,6 @@ group :development do
   gem "fasterer", require: false
   gem "license_finder", require: false
 end
+
+# https://www.ruby-lang.org/en/news/2021/11/15/date-parsing-method-regexp-dos-cve-2021-41817/
+gem "date", ">= 3.2.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,6 +40,7 @@ GEM
     concurrent-ruby (1.1.9)
     connection_pool (2.2.5)
     crass (1.0.6)
+    date (3.2.2)
     diff-lcs (1.4.4)
     dotenv (2.7.6)
     dotenv-rails (2.7.6)
@@ -208,6 +209,7 @@ DEPENDENCIES
   bootsnap (>= 1.4.4)
   brakeman
   bundler-audit
+  date (>= 3.2.1)
   dotenv-rails
   fasterer
   license_finder


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2021/11/15/date-parsing-method-regexp-dos-cve-2021-41817/